### PR TITLE
chore!: declare compatible with TYPO3 v11 and v12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     },
     "require": {
-        "typo3/cms-core": "^9.5 || ^10.4 || ^11.5"
+        "typo3/cms-core": "^9.5 || ^10.4 || ^11.5 || ^12.4"
     },
     "extra": {
         "typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.1.4',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-11.5.99',
+            'typo3' => '9.5.0-12.4.99',
         ],
     ],
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 // Register new content objects
 $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']['FOLDER'] = \Smichaelsen\FolderCobj\ContentObject\FolderContentObject::class;


### PR DESCRIPTION
BREAKING CHANGE: Drop support for v9 and v10